### PR TITLE
chapter 2:  fix Gen in Fig. 2.3 to use "unitary" lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ pacman -S texlive-binextra texlive-publishers texlive-bibtexextra texlive-mathsc
 nix shell nixpkgs#texlive.combined.scheme-full
 ```
 
+#### macOs
+```
+brew install --cask mactex
+```
+
 ### Compiling
 
 ```sh

--- a/tex/reductions.tex
+++ b/tex/reductions.tex
@@ -86,7 +86,7 @@ The proof is left as an exercise (see \autoref{ex:preimage-either-reverse}).
     \begin{tcolorbox}[width=8cm]
       \begin{pchstack}[center]
         \procedure[headlinesep=1pt]{$\game{\Game~\algo{Collision}}{\algo{H}}$}{%
-          \kappa \gets \algo{H.Gen}(\secpar) \\
+          \kappa \gets \algo{H.Gen}(\secparam) \\
           (x,x') \gets \adv(\kappa) \\
           \pcreturn (x \neq x' \wedge \algo{H.Eval}(\kappa, x) = \algo{H.Eval}(\kappa, x'))
         }


### PR DESCRIPTION
Final leftover for https://github.com/cryptography-camp/workbook/issues/6

I've used macOs to build the pdf and verify the changes hence I added the dependency installation as well.